### PR TITLE
Unit tests pass with both Python 2.7.11 and 3.5.0

### DIFF
--- a/DateSense/DSoptions.py
+++ b/DateSense/DSoptions.py
@@ -300,7 +300,7 @@ class DSoptions(object):
             the formatting should be detected.
         '''
         # If it's just one string, turn it into a collection like the methods expect
-        if isinstance(dates, str):
+        if isinstance(dates, ("".__class__, u"".__class__)):
             dates = [ dates ]
         # Do the initializing
         date_tokens = DStoken.tokenize_date(dates[0])
@@ -520,7 +520,7 @@ class DSoptions(object):
                 else:
                     hightoks[tok.text].append(tok)
         # Affect the score of those possiblities everywhere else
-        for key, value in list(hightoks.items()):
+        for key, value in hightoks.items():
             highest = None
             for tok in value:
                 if (not highest) or tok.score > highest.score:

--- a/DateSenseUnitTest.py
+++ b/DateSenseUnitTest.py
@@ -45,11 +45,11 @@ class Datetest(object):
         
         if success:
             casestr = " From: '" + (self.case if self.case else str(self.data)) + "'"
-            print "GOOD: Got: '" + self.formatstr + "'" + casestr
+            print("GOOD: Got: '" + self.formatstr + "'" + casestr)
             
         else:
-            print "FAIL: Got: '" + self.formatstr + "' Expected: '" + self.expected + "'"
-            print self.options.get_long_debug_string()
+            print("FAIL: Got: '" + self.formatstr + "' Expected: '" + self.expected + "'")
+            print(self.options.get_long_debug_string())
             
         return success
         
@@ -153,7 +153,7 @@ class TestDateSense(unittest.TestCase):
     
     
 if __name__ == '__main__':
-    print "DateSense version: " + DateSense.__version__
+    print("DateSense version: " + DateSense.__version__)
     unittest.main()
     
     


### PR DESCRIPTION
Fix issues introduced by https://github.com/humangeo/DateSense/pull/1

- Package is again functional in Python 2.7
- Unit tests no longer produce a syntax error in Python 3